### PR TITLE
fix: model selector not working if its not a table

### DIFF
--- a/swt_cm/lua/swt_cloakingmodule/cl_init.lua
+++ b/swt_cm/lua/swt_cloakingmodule/cl_init.lua
@@ -466,9 +466,11 @@ function SWT_CM:OpenJobChanger()
 
     function self:ReloadModels(data)
         self.ModelList:Clear()
+        
+        local models = istable(data.model) and data.model or {data.model}
 
         local selected = nil
-        for _, v in pairs(data.model) do
+        for _, v in pairs(models) do
             local ModelIcon = vgui.Create("SpawnIcon")
             ModelIcon:SetPos(64, 64)
             ModelIcon:SetModel(v)


### PR DESCRIPTION
Derzeit kommt ein fehler wenn versucht wird jobs auszuwählen die nur ein model haben:

```
[[SWT] Cloaking Module] lua/swt_cloakingmodule/cl_init.lua:471: bad argument #1 to 'pairs' (table expected, got string)
  1. pairs - [C]:-1
   2. ReloadModels - lua/swt_cloakingmodule/cl_init.lua:471
    3. OnSelect - lua/swt_cloakingmodule/cl_init.lua:455
     4. ChooseOption - lua/vgui/dcombobox.lua:99
      5. DoClick - lua/vgui/dcombobox.lua:203
       6. OnMouseReleased - lua/vgui/dlabel.lua:237
        7. unknown - lua/vgui/dmenuoption.lua:76
```

mit diesem pull request wird das gefixt.
